### PR TITLE
Remove obsolete core TopSpin coupling

### DIFF
--- a/src/spectrochempy/core/readers/importer.py
+++ b/src/spectrochempy/core/readers/importer.py
@@ -583,28 +583,6 @@ def _read_(*args, **kwargs):
         return Importer._read_dir(*args, **kwargs)
     raise FileNotFoundError
 
-    # protocol = kwargs.get("protocol", None)
-    # if protocol and ".scp" in protocol:
-    #     return dataset.load(filename, **kwargs)
-    #
-    # elif filename and filename.name in ("fid", "ser", "1r", "2rr", "3rrr"):
-    #     # probably a TopSpin NMR file
-    #     return read_topspin(filename, **kwargs)
-    # elif filename:
-    #     # try scp format
-    #     try:
-    #         return dataset.load(filename, **kwargs)
-    #     except Exception:
-    #         # lets try some common format
-    #         for key in ["omnic", "opus", "topspin", "labspec", "matlab", "jdx"]:
-    #             try:
-    #                 _read = getattr(scp, f"read_{key}")
-    #                 f = f"{filename}.{key}"
-    #                 return _read(f, **kwargs)
-    #             except Exception:
-    #                 pass
-    #         raise NotImplementedError
-
 
 # ======================================================================================
 # Private functions

--- a/tests/test_core/test_dataset/test_reader_api_policy.py
+++ b/tests/test_core/test_dataset/test_reader_api_policy.py
@@ -2,11 +2,15 @@
 
 """Reader API exposure policy tests."""
 
+import importlib.metadata
+import sys
+
 import pytest
 
 import spectrochempy as scp
 from spectrochempy.plugins.deps import MissingPluginError
-from spectrochempy.plugins.registry import registry
+from spectrochempy.plugins.manager import PluginManager
+from spectrochempy.plugins.registry import PluginRegistry
 
 
 def test_core_readers_are_package_level_not_dataset_methods():
@@ -45,19 +49,25 @@ def test_core_readers_are_package_level_not_dataset_methods():
 
 def test_missing_topspin_top_level_alias_is_actionable(monkeypatch):
     """Without the NMR plugin reader, scp.read_topspin points to a clear stub."""
-    scp.plugin_manager.discover()
+    isolated_registry = PluginRegistry()
+    isolated_manager = PluginManager(registry=isolated_registry)
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda group=None: [])
+    monkeypatch.setattr(scp, "plugin_manager", isolated_manager)
+    monkeypatch.setattr(scp, "registry", isolated_registry)
     monkeypatch.delitem(scp.__dict__, "read_topspin", raising=False)
-    monkeypatch.setattr(
-        registry.io,
-        "_readers",
-        {
-            name: info
-            for name, info in registry.io.available_readers.items()
-            if name != "topspin"
-        },
-    )
+    for module_name in list(sys.modules):
+        if module_name == "spectrochempy_nmr" or module_name.startswith(
+            "spectrochempy_nmr."
+        ):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    assert not any(name.startswith("spectrochempy_nmr") for name in sys.modules)
+    read_topspin = scp.read_topspin
+    assert callable(read_topspin)
+    assert not any(name.startswith("spectrochempy_nmr") for name in sys.modules)
 
     with pytest.raises(MissingPluginError, match="spectrochempy-nmr") as excinfo:
-        scp.read_topspin("missing")
+        read_topspin("missing")
 
     assert "pip install spectrochempy[nmr]" in str(excinfo.value)
+    assert not any(name.startswith("spectrochempy_nmr") for name in sys.modules)


### PR DESCRIPTION
## Summary

This PR performs a small cleanup after the NMR plugin stabilization work.

- removes an obsolete commented TopSpin/read_topspin fallback block from the core importer
- keeps the intentional scp.read_topspin compatibility stub in the core
- strengthens the reader API policy test so the missing-NMR behavior is tested with an isolated plugin manager and no NMR entry points
- verifies that accessing/calling the missing read_topspin stub does not import spectrochempy_nmr

## Intentional leftovers

The remaining TopSpin/NMR references in the core are either compatibility stubs, generic importer/file handling still needed by plugin readers, historical processing/unit behavior, or unrelated Bruker OPUS support. They are not moved in this PR to keep the change incremental.

## Checks

- pytest tests/test_plugins/ -q -> 185 passed
- pytest tests/test_core/test_dataset/test_reader_api_policy.py -q -> 2 passed
- ruff check tests/test_core/test_dataset/test_reader_api_policy.py -> passed

ruff check src/spectrochempy tests still reports existing project-wide lint issues, mostly lazy-import PLC0415 warnings unrelated to this cleanup.