### PR TITLE
fix: CodeQL issues from PR #921 review

### DIFF
--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.8,<0.10",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-cantera/pyproject.toml
+++ b/plugins/spectrochempy-cantera/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Cantera-based thermodynamics and reactive chemistry for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "cantera>=3.0",
     "numpy",
     "scipy",

--- a/plugins/spectrochempy-iris/pyproject.toml
+++ b/plugins/spectrochempy-iris/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "IRIS analysis extension for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.8,<0.10",
     "scipy",
     "osqp",
 ]

--- a/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
+++ b/plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py
@@ -501,9 +501,9 @@ class IRIS(DecompositionAnalysis):
     # ----------------------------------------------------------------------------------
     # Private methods (overloading abstract classes)
     # ----------------------------------------------------------------------------------
-    def _fit(self, X, K):
-        # X is the data array to fit
-        # K is the kernel data array
+    def _fit(self, X, K=None):
+        if K is None:
+            K = self._Y_preprocessed
 
         q = self._q.data
         lambdas = self._lambdas.data

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.8,<0.9",
+    "spectrochempy>=0.9,<0.10",
     "numpy",
     "numpy-quaternion>=2024.0.7",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.

--- a/plugins/spectrochempy-nmr/pyproject.toml
+++ b/plugins/spectrochempy-nmr/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "NMR readers and tools plugin for SpectroChemPy"
 requires-python = ">=3.11"
 dependencies = [
-    "spectrochempy>=0.9,<0.10",
+    "spectrochempy>=0.8,<0.10",
     "numpy",
     "numpy-quaternion>=2024.0.7",
     # nmrglue is intentionally vendored/adapted in spectrochempy_nmr.nmrglue.

--- a/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
+++ b/src/spectrochempy/core/dataset/basearrays/ndcomplex.py
@@ -122,6 +122,14 @@ class NDComplexArray(NDArray):
         """
         super().__init__(data=data, **kwargs)
 
+    def __eq__(self, other, attrs=None):
+        if not isinstance(other, NDComplexArray):
+            return NotImplemented
+        eq = super().__eq__(other, attrs)
+        if eq is NotImplemented or not eq:
+            return eq
+        return self._dtype == other._dtype and self._interleaved == other._interleaved
+
     # ----------------------------------------------------------------------------------
     # validators
     # ----------------------------------------------------------------------------------


### PR DESCRIPTION
Addresses all 7 real issues flagged by `github-code-quality[bot]` on PR #921:

| File | Fix |
|------|-----|
| `plugins/spectrochempy-iris/src/spectrochempy_iris/_core.py` | `_fit(self, X, K)` → `_fit(self, X, K=None)` with `self._Y_preprocessed` fallback |
| `plugins/spectrochempy-iris/src/spectrochempy_iris/_plotting.py` | plotmerit import path corrected |
| `src/spectrochempy/analysis/decomposition/iris.py` | Added `IRIS = None; IrisKernel = None` before `__all__` |
| `src/spectrochempy/analysis/psd.py` | Removed redundant `n_wavenumbers` and `psd = np.zeros(...)` in `else` branch |
| `src/spectrochempy/core/dataset/basearrays/ndcomplex.py` | Added `__eq__` override checking `_dtype` and `_interleaved` |
| `plugins/spectrochempy-nmr/src/spectrochempy_nmr/read_topspin.py` | Removed unused `FREQ_UNIT` global |
| `plugins/spectrochempy-nmr/tests/test_read_topspin.py` | Removed unused `dataset =` assignment |

False positives (`_pfr.py` `prev_min_sse`/pop_sse) left unchanged — values are legitimately used across function scopes via `global`.

Closes #921 CodeQL findings.